### PR TITLE
Set the component type to `library`

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,6 +9,6 @@ metadata:
   annotations:
     github.com/project-slug: coopnorge/kubernetes-schemas
 spec:
-  type: component
+  type: library
   lifecycle: production
   owner: cloud-platform


### PR DESCRIPTION
There are currently 3 know Component types in Inventory (Backstage). `service`, `website` and `library`. I think `library` is the right thing for this repository.