### PR TITLE
chore: Change labels to tags in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,11 @@
+#nonk8s
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: kubernetes-schemas
   title: Kubernetes Schemas
   description: Manifest validation schemas for our kubernetes cluster APIs
-  lables:
+  tags:
     - "kubernetes"
   annotations:
     github.com/project-slug: coopnorge/kubernetes-schemas


### PR DESCRIPTION
`labels` was misspelt, but it looks like labels should be key-value pairs: https://backstage.io/docs/features/software-catalog/descriptor-format/#labels-optional

`tags` should be more appropriate for this.

ref: https://github.com/coopnorge/cloud-platform-team/issues/1031