### PR TITLE
feat: Add schema for ConfigConnector and ConfigConnectorContext

### DIFF
--- a/api-platform/configconnector-core-v1beta1.json
+++ b/api-platform/configconnector-core-v1beta1.json
@@ -1,0 +1,132 @@
+{
+  "description": "ConfigConnector is the Schema for the configconnectors API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "not": {
+                "required": [
+                  "googleServiceAccount"
+                ]
+              },
+              "required": [
+                "credentialSecretName"
+              ]
+            },
+            {
+              "not": {
+                "required": [
+                  "credentialSecretName"
+                ]
+              },
+              "required": [
+                "googleServiceAccount"
+              ]
+            }
+          ],
+          "properties": {
+            "mode": {
+              "enum": [
+                "cluster"
+              ]
+            }
+          }
+        },
+        {
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "googleServiceAccount"
+                ]
+              },
+              {
+                "required": [
+                  "credentialSecretName"
+                ]
+              }
+            ]
+          },
+          "properties": {
+            "mode": {
+              "enum": [
+                "namespaced"
+              ]
+            }
+          }
+        }
+      ],
+      "description": "ConfigConnectorSpec defines the desired state of ConfigConnector",
+      "properties": {
+        "actuationMode": {
+          "description": "The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.\nThis can be either 'Reconciling' or 'Paused'.\nIn 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.\nIf Config Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext (CCC) takes precedence.\nIf CCC doesn't define a value but ConfigConnector (CC) does, we defer to that value. Otherwise,\nthe default is 'Reconciling' where resources get actuated.",
+          "enum": [
+            "Reconciling",
+            "Paused"
+          ],
+          "type": "string"
+        },
+        "credentialSecretName": {
+          "description": "The Kubernetes secret that contains the Google Service Account Key's credentials to be used by ConfigConnector to authenticate with Google Cloud APIs. This field is used only when in cluster mode.\nIt's recommended to use `googleServiceAccount` when running ConfigConnector in Google Kubernetes Engine (GKE) clusters with Workload Identity enabled.\nThis field cannot be specified together with `googleServiceAccount`.",
+          "type": "string"
+        },
+        "googleServiceAccount": {
+          "description": "The Google Service Account to be used by Config Connector to authenticate with Google Cloud APIs. This field is used only when running in cluster mode with Workload Identity enabled.\nSee Google Kubernetes Engine (GKE) workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for details. This field cannot be specified together with `credentialSecretName`.\nFor namespaced mode, use `googleServiceAccount` in ConfigConnectorContext CRD to specify the Google Service Account to be used to authenticate with Google Cloud APIs per namespace.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "The mode that Config Connector will run in. This can be either 'cluster' or 'namespaced'. The default is 'namespaced'.\nCluster mode uses a single Google Service Account to create and manage resources, even if you are using Config Connector to manage multiple Projects.\nYou must specify either `credentialSecretName` or `googleServiceAccount` when in cluster mode, but not both.\nNamespaced mode allows you to use different Google service accounts for different Projects.\nWhen in namespaced mode, you must create a ConfigConnectorContext object per namespace that you want to enable Config Connector in, and each must set `googleServiceAccount` to specify the Google Service Account to be used to authenticate with Google Cloud APIs for the namespace.",
+          "enum": [
+            "cluster",
+            "namespaced"
+          ],
+          "type": "string"
+        },
+        "stateIntoSpec": {
+          "description": "StateIntoSpec is the user override of the default value for the\n'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is\nunset for a resource.\nIf the field is set in both the ConfigConnector object and the\nConfigConnectorContext object is in the namespaced mode, then the value\nin the ConfigConnectorContext object will be used.\n'Absent' means that unspecified fields in the resource spec stay\nunspecified after successful reconciliation.\n'Merge' means that unspecified fields in the resource spec are populated\nafter a successful reconciliation if those unspecified fields are\ncomputed/defaulted by the API. It is only applicable to resources\nsupporting the 'Merge' option.",
+          "enum": [
+            "Absent",
+            "Merge"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "ConfigConnectorStatus defines the observed state of ConfigConnector",
+      "properties": {
+        "errors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "healthy": {
+          "type": "boolean"
+        },
+        "phase": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "healthy"
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/api-platform/configconnectorcontext-core-v1beta1.json
+++ b/api-platform/configconnectorcontext-core-v1beta1.json
@@ -1,0 +1,87 @@
+{
+  "description": "ConfigConnectorContext is the Schema for the ConfigConnectorContexts API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ConfigConnectorContextSpec defines the desired state of ConfigConnectorContext",
+      "properties": {
+        "actuationMode": {
+          "description": "The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.\nThis can be either 'Reconciling' or 'Paused'. The default is 'Reconciling' where resources get actuated.\nIn 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.",
+          "enum": [
+            "Reconciling",
+            "Paused"
+          ],
+          "type": "string"
+        },
+        "billingProject": {
+          "description": "Specifies the project to use for preconditions, quota and billing.\nShould only be used when requestProjectPolicy is set to BILLING_PROJECT.",
+          "type": "string"
+        },
+        "googleServiceAccount": {
+          "description": "The Google Service Account to be used by Config Connector to\nauthenticate with Google Cloud APIs in the associated namespace.",
+          "type": "string"
+        },
+        "requestProjectPolicy": {
+          "description": "Specifies which project to use for preconditions, quota, and billing for\nrequests made to Google Cloud APIs for resources in the associated\nnamespace. Must be one of 'SERVICE_ACCOUNT_PROJECT',\n'RESOURCE_PROJECT', or 'BILLING_PROJECT. Defaults to 'SERVICE_ACCOUNT_PROJECT'. If set to\n'SERVICE_ACCOUNT_PROJECT', uses the project that the Google Service\nAccount belongs to. If set to 'RESOURCE_PROJECT', uses the project that\nthe resource belongs to. If set to 'BILLING_PROJECT', uses the project specified by spec.billingProject.",
+          "enum": [
+            "SERVICE_ACCOUNT_PROJECT",
+            "RESOURCE_PROJECT",
+            "BILLING_PROJECT"
+          ],
+          "type": "string"
+        },
+        "stateIntoSpec": {
+          "description": "StateIntoSpec is the user override of the default value for the\n'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is\nunset for a resource.\n'Absent' means that unspecified fields in the resource spec stay\nunspecified after successful reconciliation.\n'Merge' means that unspecified fields in the resource spec are populated\nafter a successful reconciliation if those unspecified fields are\ncomputed/defaulted by the API. It is only applicable to resources\nsupporting the 'Merge' option.",
+          "enum": [
+            "Absent",
+            "Merge"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "Version specifies the exact addon version to be deployed, eg 1.2.3\nOnly limited versions are supported; currently we are only supporting\nthe operator version and the previous minor version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "googleServiceAccount"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "description": "ConfigConnectorContextStatus defines the observed state of ConfigConnectorContext",
+      "properties": {
+        "errors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "healthy": {
+          "type": "boolean"
+        },
+        "phase": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "healthy"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/gke-schemas/configconnector-core-v1beta1.json
+++ b/gke-schemas/configconnector-core-v1beta1.json
@@ -1,0 +1,132 @@
+{
+  "description": "ConfigConnector is the Schema for the configconnectors API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "not": {
+                "required": [
+                  "googleServiceAccount"
+                ]
+              },
+              "required": [
+                "credentialSecretName"
+              ]
+            },
+            {
+              "not": {
+                "required": [
+                  "credentialSecretName"
+                ]
+              },
+              "required": [
+                "googleServiceAccount"
+              ]
+            }
+          ],
+          "properties": {
+            "mode": {
+              "enum": [
+                "cluster"
+              ]
+            }
+          }
+        },
+        {
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "googleServiceAccount"
+                ]
+              },
+              {
+                "required": [
+                  "credentialSecretName"
+                ]
+              }
+            ]
+          },
+          "properties": {
+            "mode": {
+              "enum": [
+                "namespaced"
+              ]
+            }
+          }
+        }
+      ],
+      "description": "ConfigConnectorSpec defines the desired state of ConfigConnector",
+      "properties": {
+        "actuationMode": {
+          "description": "The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.\nThis can be either 'Reconciling' or 'Paused'.\nIn 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.\nIf Config Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext (CCC) takes precedence.\nIf CCC doesn't define a value but ConfigConnector (CC) does, we defer to that value. Otherwise,\nthe default is 'Reconciling' where resources get actuated.",
+          "enum": [
+            "Reconciling",
+            "Paused"
+          ],
+          "type": "string"
+        },
+        "credentialSecretName": {
+          "description": "The Kubernetes secret that contains the Google Service Account Key's credentials to be used by ConfigConnector to authenticate with Google Cloud APIs. This field is used only when in cluster mode.\nIt's recommended to use `googleServiceAccount` when running ConfigConnector in Google Kubernetes Engine (GKE) clusters with Workload Identity enabled.\nThis field cannot be specified together with `googleServiceAccount`.",
+          "type": "string"
+        },
+        "googleServiceAccount": {
+          "description": "The Google Service Account to be used by Config Connector to authenticate with Google Cloud APIs. This field is used only when running in cluster mode with Workload Identity enabled.\nSee Google Kubernetes Engine (GKE) workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for details. This field cannot be specified together with `credentialSecretName`.\nFor namespaced mode, use `googleServiceAccount` in ConfigConnectorContext CRD to specify the Google Service Account to be used to authenticate with Google Cloud APIs per namespace.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "The mode that Config Connector will run in. This can be either 'cluster' or 'namespaced'. The default is 'namespaced'.\nCluster mode uses a single Google Service Account to create and manage resources, even if you are using Config Connector to manage multiple Projects.\nYou must specify either `credentialSecretName` or `googleServiceAccount` when in cluster mode, but not both.\nNamespaced mode allows you to use different Google service accounts for different Projects.\nWhen in namespaced mode, you must create a ConfigConnectorContext object per namespace that you want to enable Config Connector in, and each must set `googleServiceAccount` to specify the Google Service Account to be used to authenticate with Google Cloud APIs for the namespace.",
+          "enum": [
+            "cluster",
+            "namespaced"
+          ],
+          "type": "string"
+        },
+        "stateIntoSpec": {
+          "description": "StateIntoSpec is the user override of the default value for the\n'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is\nunset for a resource.\nIf the field is set in both the ConfigConnector object and the\nConfigConnectorContext object is in the namespaced mode, then the value\nin the ConfigConnectorContext object will be used.\n'Absent' means that unspecified fields in the resource spec stay\nunspecified after successful reconciliation.\n'Merge' means that unspecified fields in the resource spec are populated\nafter a successful reconciliation if those unspecified fields are\ncomputed/defaulted by the API. It is only applicable to resources\nsupporting the 'Merge' option.",
+          "enum": [
+            "Absent",
+            "Merge"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "ConfigConnectorStatus defines the observed state of ConfigConnector",
+      "properties": {
+        "errors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "healthy": {
+          "type": "boolean"
+        },
+        "phase": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "healthy"
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/gke-schemas/configconnectorcontext-core-v1beta1.json
+++ b/gke-schemas/configconnectorcontext-core-v1beta1.json
@@ -1,0 +1,87 @@
+{
+  "description": "ConfigConnectorContext is the Schema for the ConfigConnectorContexts API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ConfigConnectorContextSpec defines the desired state of ConfigConnectorContext",
+      "properties": {
+        "actuationMode": {
+          "description": "The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.\nThis can be either 'Reconciling' or 'Paused'. The default is 'Reconciling' where resources get actuated.\nIn 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.",
+          "enum": [
+            "Reconciling",
+            "Paused"
+          ],
+          "type": "string"
+        },
+        "billingProject": {
+          "description": "Specifies the project to use for preconditions, quota and billing.\nShould only be used when requestProjectPolicy is set to BILLING_PROJECT.",
+          "type": "string"
+        },
+        "googleServiceAccount": {
+          "description": "The Google Service Account to be used by Config Connector to\nauthenticate with Google Cloud APIs in the associated namespace.",
+          "type": "string"
+        },
+        "requestProjectPolicy": {
+          "description": "Specifies which project to use for preconditions, quota, and billing for\nrequests made to Google Cloud APIs for resources in the associated\nnamespace. Must be one of 'SERVICE_ACCOUNT_PROJECT',\n'RESOURCE_PROJECT', or 'BILLING_PROJECT. Defaults to 'SERVICE_ACCOUNT_PROJECT'. If set to\n'SERVICE_ACCOUNT_PROJECT', uses the project that the Google Service\nAccount belongs to. If set to 'RESOURCE_PROJECT', uses the project that\nthe resource belongs to. If set to 'BILLING_PROJECT', uses the project specified by spec.billingProject.",
+          "enum": [
+            "SERVICE_ACCOUNT_PROJECT",
+            "RESOURCE_PROJECT",
+            "BILLING_PROJECT"
+          ],
+          "type": "string"
+        },
+        "stateIntoSpec": {
+          "description": "StateIntoSpec is the user override of the default value for the\n'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is\nunset for a resource.\n'Absent' means that unspecified fields in the resource spec stay\nunspecified after successful reconciliation.\n'Merge' means that unspecified fields in the resource spec are populated\nafter a successful reconciliation if those unspecified fields are\ncomputed/defaulted by the API. It is only applicable to resources\nsupporting the 'Merge' option.",
+          "enum": [
+            "Absent",
+            "Merge"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "Version specifies the exact addon version to be deployed, eg 1.2.3\nOnly limited versions are supported; currently we are only supporting\nthe operator version and the previous minor version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "googleServiceAccount"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "description": "ConfigConnectorContextStatus defines the observed state of ConfigConnectorContext",
+      "properties": {
+        "errors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "healthy": {
+          "type": "boolean"
+        },
+        "phase": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "healthy"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
```bash
kubectl get crd configconnectors.core.cnrm.cloud.google.com -o jsonpath='{.spec.versions[?(@.name=="v1beta1")].schema.openAPIV3Schema}' | jq > gke-schemas/configconnector-core-v1beta1.json
kubectl get crd configconnectorcontexts.core.cnrm.cloud.google.com -o jsonpath='{.spec.versions[?(@.name=="v1beta1")].schema.openAPIV3Schema}' | jq > gke-schemas/configconnectorcontexts-core-v1beta1.json
```

required for https://github.com/coopnorge/kubernetes-base-manifests/pull/671

ref: https://github.com/coopnorge/kubernetes-base-manifests/issues/670